### PR TITLE
Small fixes and cleanups

### DIFF
--- a/accounts.tf
+++ b/accounts.tf
@@ -24,14 +24,13 @@ module "accounts" {
 
   account_name             = each.value["account_name"]
   account_email            = each.value["account_email"]
-  parent_ou_id             = local.ou_name_to_id[lookup(each.value, "parent_ou_name", "Workloads")]
+  parent_ou_id             = local.ou_name_to_id[each.value.parent_ou_name]
   admin_permission_set_arn = var.disable_sso_management ? null : aws_ssoadmin_permission_set.admin_permission_set[0].arn
   admin_group_id           = var.disable_sso_management ? null : aws_identitystore_group.admin_group[0].group_id
   billing_contact          = var.global_billing_contact
   security_contact         = var.global_security_contact
-  operations_contact       = lookup(each.value, "operations_contact", var.global_operations_contact)
-  primary_contact          = lookup(each.value, "primary_contact", var.global_primary_contact)
+  operations_contact       = lookup(each.value, "operations_contact", null) == null ? var.global_operations_contact : each.value.operations_contact
+  primary_contact          = lookup(each.value, "primary_contact", null) == null ? var.global_primary_contact : each.value.primary_contact
   disable_sso_management   = var.disable_sso_management
-  delegated_admin          = lookup(each.value, "delegated_admin", [])
+  delegated_admin          = each.value.delegated_admin
 }
-

--- a/declarative_policies.tf
+++ b/declarative_policies.tf
@@ -77,17 +77,14 @@ data "aws_iam_policy_document" "declarative_policy_bucket_policy" {
 # Declarative Policies
 #
 module "declarative_policies" {
-  for_each           = var.declarative_policies
+  for_each = var.declarative_policies
+
   source             = "./modules/declarative_policies"
   policy_type        = "DECLARATIVE_POLICY_EC2"
-  policy_name        = each.value["policy_name"]
-  policy_description = each.value["policy_description"]
-  policy_json        = templatefile(fileexists(each.value["policy_json_file"]) ? each.value["policy_json_file"] : "${path.module}/${each.value["policy_json_file"]}", lookup(each.value, "policy_vars", {}))
-  policy_targets     = lookup(each.value, "policy_targets", ["Root"])
+  policy_name        = each.value.policy_name
+  policy_description = each.value.policy_description
+  policy_json        = templatefile(fileexists(each.value.policy_json_file) ? each.value.policy_json_file : "${path.module}/${each.value.policy_json_file}", each.value.policy_vars)
+  policy_targets     = each.value.policy_targets
   ou_name_to_id      = local.ou_name_to_id # Pass the map to avoid regenerating it
   root_ou            = aws_organizations_organization.org.roots[0].id
-}
-
-output "declarative_policy_bucket" {
-  value = aws_s3_bucket.declarative_policy_bucket[0].id
 }

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 terraform {
+  required_version = ">= 1.0, < 2.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -21,28 +22,8 @@ terraform {
   }
 }
 
-# Payer ID
-data "external" "get_caller_identity" {
-  program = ["aws", "sts", "get-caller-identity"]
-}
-data "aws_regions" "current" {}
-
-#
-# Security Service flags
-variable "security_services" {
-  description = "explictly disable or not manage a security service"
-  default = {
-    disable_guardduty   = "false"
-    disable_macie       = "false"
-    disable_inspector   = "false"
-    disable_securityhub = "false"
-  }
-}
-
 locals {
-  payer_account_id = data.external.get_caller_identity.result.Account
-  regions          = data.aws_regions.current.names
-  default_tags     = var.tag_set
+  default_tags = var.tag_set
   security_services = merge(
     tomap({
       disable_guardduty   = "false"

--- a/modules/scp/main.tf
+++ b/modules/scp/main.tf
@@ -45,8 +45,8 @@ resource "aws_organizations_policy" "scp" {
 }
 
 resource "aws_organizations_policy_attachment" "scp_attachment" {
-  count     = length(var.policy_targets)
+  for_each  = toset(var.policy_targets)
   policy_id = aws_organizations_policy.scp.id
-  target_id = var.policy_targets[count.index] == "Root" ? var.root_ou : var.ou_name_to_id[var.policy_targets[count.index]]
+  target_id = each.value == "Root" ? var.root_ou : var.ou_name_to_id[each.value]
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,17 +16,28 @@ output "org_name" {
   value = var.organization_name
 }
 
+output "macie_key_arn" {
+  description = "ARN of the KMS Key used by Macie"
+  value       = var.macie_bucket_name == null ? null : aws_kms_key.macie_key[0].arn
+}
+
 output "org_id" {
   value = data.aws_organizations_organization.org.id
 }
 
-output "security_account_id" {
-  value = module.security_account.account_id
+output "org_name" {
+  description = "Name of the AWS Organization"
+  value       = var.organization_name
 }
 
-# Things to pass to the Security Services Regional Modules
-output "macie_key_arn" {
-  value = var.macie_bucket_name == null ? null : aws_kms_key.macie_key[0].arn
+output "ou_name_to_id" {
+  description = "Map of OU Names to OU IDs"
+  value       = local.ou_name_to_id
+}
+
+output "security_account_id" {
+  description = "ID of the Security Account"
+  value       = module.security_account.account_id
 }
 
 output "sso_instance_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-output "org_name" {
-  value = var.organization_name
+
+output "declarative_policy_bucket" {
+  description = "Bucket used to store declarative policies"
+  value       = var.declarative_policy_bucket_name != null ? aws_s3_bucket.declarative_policy_bucket[0].id : null
 }
 
 output "macie_key_arn" {
@@ -22,7 +24,8 @@ output "macie_key_arn" {
 }
 
 output "org_id" {
-  value = data.aws_organizations_organization.org.id
+  description = "ID of the AWS Organization"
+  value       = data.aws_organizations_organization.org.id
 }
 
 output "org_name" {

--- a/policies/DisableRegionsPolicy.json.tftpl
+++ b/policies/DisableRegionsPolicy.json.tftpl
@@ -49,7 +49,7 @@
       "Effect": "Deny",
       "Condition": {
         "StringNotEquals": {
-          "aws:RequestedRegion": ${jsonencode( [ for region in allowed_regions : "${region}"])}
+          "aws:RequestedRegion": ${allowed_regions}
         },
         "ArnNotLike": {
           "aws:PrincipalArn": [

--- a/rcps.tf
+++ b/rcps.tf
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 module "rcp" {
-  for_each           = var.resource_control_policies
+  for_each = var.resource_control_policies
+
   source             = "./modules/rcp"
-  policy_name        = each.value["policy_name"]
-  policy_description = each.value["policy_description"]
-  policy_json        = templatefile(fileexists(each.value["policy_json_file"]) ? each.value["policy_json_file"] : "${path.module}/${each.value["policy_json_file"]}", lookup(each.value, "policy_vars", {}))
-  policy_targets     = lookup(each.value, "policy_targets", ["Root"])
+  policy_name        = each.value.policy_name
+  policy_description = each.value.policy_description
+  policy_json        = templatefile(fileexists(each.value.policy_json_file) ? each.value.policy_json_file : "${path.module}/${each.value.policy_json_file}", each.value.policy_vars)
+  policy_targets     = each.value.policy_targets
   ou_name_to_id      = local.ou_name_to_id # Pass the map to avoid regenerating it
   root_ou            = aws_organizations_organization.org.roots[0].id
 }

--- a/scps.tf
+++ b/scps.tf
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 module "scp" {
-  for_each           = var.service_control_policies
+  for_each = var.service_control_policies
+
   source             = "./modules/scp"
-  policy_name        = each.value["policy_name"]
-  policy_description = each.value["policy_description"]
-  policy_json        = templatefile(fileexists(each.value["policy_json_file"]) ? each.value["policy_json_file"] : "${path.module}/${each.value["policy_json_file"]}", lookup(each.value, "policy_vars", {}))
-  policy_targets     = lookup(each.value, "policy_targets", ["Root"])
+  policy_name        = each.value.policy_name
+  policy_description = each.value.policy_description
+  policy_json        = templatefile(fileexists(each.value.policy_json_file) ? each.value.policy_json_file : "${path.module}/${each.value.policy_json_file}", each.value.policy_vars)
+  policy_targets     = each.value.policy_targets
   ou_name_to_id      = local.ou_name_to_id # Pass the map to avoid regenerating it
   root_ou            = aws_organizations_organization.org.roots[0].id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -273,11 +273,19 @@ variable "organization_units" {
 variable "declarative_policy_bucket_name" {
   description = "Name of S3 Bucket for Declarative Policy Reports"
   default     = null
+  type        = string
 }
 
 variable "declarative_policies" {
   description = "Map of Declarative Policies to deploy"
   default     = {}
+  type = map(object({
+    policy_name        = string
+    policy_description = string
+    policy_json_file   = string
+    policy_targets     = optional(list(string), ["Root"])
+    policy_vars        = optional(map(string), {})
+  }))
 }
 
 #

--- a/variables.tf
+++ b/variables.tf
@@ -115,9 +115,30 @@ variable "accounts" {
   description = "AWS accounts to provision in the organization"
   type = map(
     object({
-      account_name   = string
-      account_email  = string
-      parent_ou_name = optional(string)
+      account_name    = string
+      account_email   = string
+      delegated_admin = optional(list(string), [])
+      operations_contact = optional(object({
+        name          = string
+        title         = string
+        email_address = string
+        phone_number  = string
+      }))
+      primary_contact = optional(object({
+        full_name          = string
+        company_name       = optional(string)
+        address_line_1     = string
+        address_line_2     = optional(string)
+        address_line_3     = optional(string)
+        city               = string
+        district_or_county = optional(string)
+        state_or_region    = optional(string)
+        postal_code        = string
+        country_code       = string
+        phone_number       = string
+        website_url        = optional(string)
+      }))
+      parent_ou_name = optional(string, "Workloads")
     })
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -256,6 +256,15 @@ variable "service_control_policies" {
 variable "resource_control_policies" {
   description = "Map of RCPs to deploy"
   default     = {}
+  type = map(
+    object({
+      policy_name        = string
+      policy_description = string
+      policy_json_file   = string
+      policy_targets     = optional(list(string), ["Root"])
+      policy_vars        = optional(map(string), {})
+    })
+  )
 }
 
 variable "organization_units" {

--- a/variables.tf
+++ b/variables.tf
@@ -317,3 +317,16 @@ variable "deploy_audit_role" {
   type        = bool
   default     = true
 }
+
+#
+# Security Service flags
+variable "security_services" {
+  description = "explictly disable or not manage a security service"
+  type        = map(string)
+  default = {
+    disable_guardduty   = "false"
+    disable_macie       = "false"
+    disable_inspector   = "false"
+    disable_securityhub = "false"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -64,7 +64,7 @@ variable "session_duration" {
 
   validation {
     # Regex taken from https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sso-permissionset.html#cfn-sso-permissionset-sessionduration and modified to use HCL2 compatiable syntax
-    condition     = can(regex("^(-?)P(?=\\d|T\\d)(?:(\\d+)Y)?(?:(\\d+)M)?(?:(\\d+)([DW]))?(?:T(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+(?:\\.\\d+)?)S)?)?$", var.session_duration))
+    condition     = can(regex("^P(?:(\\d+Y)?(\\d+M)?(\\d+D)?(T(\\d+H)?(\\d+M)?(\\d+S)?)?)$", var.session_duration))
     error_message = "Session duration must use the ISO8601 duration format. ${var.session_duration} isn't a valid duration string"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -247,8 +247,8 @@ variable "service_control_policies" {
       policy_name        = string
       policy_description = string
       policy_json_file   = string
-      policy_targets     = optional(list(string))
-      policy_vars        = optional(map(any))
+      policy_targets     = optional(list(string), ["Root"])
+      policy_vars        = optional(map(string), {})
     })
   )
 }


### PR DESCRIPTION
* Fixed `session_duration` variable validation regex - Terraform uses RE2, not PCRE for regex. I tested the pattern but didn't do an end to end test before pushing 🤦 
* Cleanup accounts variables and how they're used, including sane defaults and less reliance on `lookup()`. All outputs are in `outputs.tf` and sorted alphabetically.
* Clean up declarative policy handling including type hints and cleaner variable references
* Clean up SCP handling - more of the same
* Clean up RCP handling - the same again
* Clean up variables and locals. Variables belong in `varaibles.tf`. Remove anything that isn't referenced