### PR TITLE
Region agnostic

### DIFF
--- a/billing.tf
+++ b/billing.tf
@@ -86,7 +86,7 @@ data "aws_iam_policy_document" "allow_billing_logging" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:cur:us-east-1:${aws_organizations_account.payer.id}:definition/*"]
+      values   = ["arn:aws:cur:${data.aws_region.current.name}:${aws_organizations_account.payer.id}:definition/*"]
     }
 
   }
@@ -112,7 +112,7 @@ resource "aws_cur_report_definition" "cur_report_definition" {
   additional_schema_elements = ["RESOURCES", "SPLIT_COST_ALLOCATION_DATA"]
   s3_bucket                  = aws_s3_bucket.billing_logs[0].id
   s3_prefix                  = "athena-cur-report"
-  s3_region                  = "us-east-1"
+  s3_region                  = data.aws_region.current.name
   additional_artifacts       = ["ATHENA"]
   report_versioning          = "OVERWRITE_REPORT"
 }

--- a/examples/pipeline/main.tf
+++ b/examples/pipeline/main.tf
@@ -22,7 +22,7 @@ terraform {
 
   # This is configured in the $env.backend file
   backend "s3" {
-    region = "us-east-1"
+
   }
 }
 

--- a/examples/pipeline/main.tf
+++ b/examples/pipeline/main.tf
@@ -20,7 +20,7 @@ terraform {
   }
   required_version = ">= 0.14.9"
 
-  # This is configured in the $env.backend file
+  # This is configured in the $env.tfbackend file, see sample.tfbackend
   backend "s3" {
 
   }

--- a/examples/pipeline/sample.tfbackend
+++ b/examples/pipeline/sample.tfbackend
@@ -12,5 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# See documentation for implementation details
+# https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+
 bucket="org-kickstart-13456789012"
 key="org-kickstart.tfstate"
+region = "us-east-1"

--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,6 @@ locals {
 # Create Default Provider for Management Account
 #
 provider "aws" {
-  region = "us-east-1"
   default_tags {
     tags = local.default_tags
   }
@@ -54,7 +53,6 @@ provider "aws" {
 
 provider "aws" {
   alias  = "security-account"
-  region = "us-east-1"
   assume_role {
     role_arn = "arn:aws:iam::${module.security_account.account_id}:role/OrganizationAccountAccessRole"
   }
@@ -62,3 +60,5 @@ provider "aws" {
     tags = local.default_tags
   }
 }
+
+data "aws_region" "current" {}


### PR DESCRIPTION
This removes static references to us-east-1 and leverages the aws_region data provider where possible. For the example, the region is removed from the provider and example backend config updated with it and a link to the documentation on how to use it.

