### PR TITLE
Allow overriding the services enabled for an org

### DIFF
--- a/organization.tf
+++ b/organization.tf
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 #
-# Define the Organization & enable as many services as makes sense
+# Define the Organization & enable services
 #
-resource "aws_organizations_organization" "org" {
-  aws_service_access_principals = [
+# Default service setup with what makes sense.
+
+locals {
+  default_aws_service_access_principals = [
     "access-analyzer.amazonaws.com",
     "account.amazonaws.com",
     "backup.amazonaws.com",
@@ -43,7 +46,7 @@ resource "aws_organizations_organization" "org" {
     "sso.amazonaws.com",
   ]
 
-  enabled_policy_types = [
+  default_enabled_policy_types = [
     "AISERVICES_OPT_OUT_POLICY",
     "BACKUP_POLICY",
     "DECLARATIVE_POLICY_EC2",
@@ -51,6 +54,14 @@ resource "aws_organizations_organization" "org" {
     "SERVICE_CONTROL_POLICY",
     "TAG_POLICY"
   ]
+}
+
+
+# Create the organization
+resource "aws_organizations_organization" "org" {
+  aws_service_access_principals = var.aws_service_access_principals != null ? var.aws_service_access_principals : local.default_aws_service_access_principals
+
+  enabled_policy_types = var.enabled_policy_types != null ? var.enabled_policy_types : local.default_enabled_policy_types
 
   feature_set = "ALL"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -357,6 +357,19 @@ variable "declarative_policies" {
   }))
 }
 
+variable "aws_service_access_principals" {
+  description = "List of AWS service principals to enable in the organization"
+  type        = list(string)
+  default     = null
+}
+
+variable "enabled_policy_types" {
+  description = "List of enabled policy types for the organization"
+  type        = list(string)
+  default     = null
+}
+
+
 #
 # Audit Role
 #


### PR DESCRIPTION
The current setup is a bit rigid, explicitly setting a list of services enabled for the organisation that needs to be modified. 

While this is a good default, we should be able to override it with our own list. This simply adds a couple variables to provide your own list. When either is set it is used, if untouched then the default is used.