### PR TITLE
Allow disabling Stacksets delegation

### DIFF
--- a/security_account.tf
+++ b/security_account.tf
@@ -48,6 +48,7 @@ module "security_account" {
 
 # And delegate power to it
 resource "aws_organizations_delegated_administrator" "cloudformation" {
+  count             = local.security_services["disable_stacksets"] ? 0 : 1
   account_id        = module.security_account.account_id
   service_principal = "member.org.stacksets.cloudformation.amazonaws.com"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -388,6 +388,7 @@ variable "security_services" {
     disable_macie       = "false"
     disable_inspector   = "false"
     disable_securityhub = "false"
+    disable_stacksets   = "false"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -382,7 +382,13 @@ variable "deploy_audit_role" {
 # Security Service flags
 variable "security_services" {
   description = "Explicitly disable or not manage a security service"
-  type        = map(string)
+  type        = object({
+    disable_guardduty   = optional(bool, false)
+    disable_macie       = optional(bool, false)
+    disable_inspector   = optional(bool, false)
+    disable_securityhub = optional(bool, false)
+    disable_stacksets   = optional(bool, false)
+  })
   default = {
     disable_guardduty   = "false"
     disable_macie       = "false"


### PR DESCRIPTION
There are specific cases where we don't want to delegate stacksets to the security account (in our case, security account is primarily used for processing findings)