### PR TITLE
Allow definition of Region for SSO Instance

### DIFF
--- a/accounts.tf
+++ b/accounts.tf
@@ -32,5 +32,6 @@ module "accounts" {
   operations_contact       = lookup(each.value, "operations_contact", var.global_operations_contact)
   primary_contact          = lookup(each.value, "primary_contact", var.global_primary_contact)
   disable_sso_management   = var.disable_sso_management
+  sso_instance_region      = var.sso_instance_region
 }
 

--- a/audit-role.tf
+++ b/audit-role.tf
@@ -61,12 +61,12 @@ resource "aws_cloudformation_stack_set" "audit_role" {
 }
 
 resource "aws_cloudformation_stack_set_instance" "audit_role" {
-  count          = var.deploy_audit_role == true ? 1 : 0
-  provider       = aws.security-account
-  region         = "us-east-1"
-  call_as        = "DELEGATED_ADMIN"
-  retain_stack   = true
-  stack_set_name = aws_cloudformation_stack_set.audit_role[0].name
+  count                     = var.deploy_audit_role == true ? 1 : 0
+  provider                  = aws.security-account
+  stack_set_instance_region = "us-east-1"
+  call_as                   = "DELEGATED_ADMIN"
+  retain_stack              = true
+  stack_set_name            = aws_cloudformation_stack_set.audit_role[0].name
   deployment_targets {
     organizational_unit_ids = [aws_organizations_organization.org.roots[0].id]
   }

--- a/examples/pipeline/main.tf
+++ b/examples/pipeline/main.tf
@@ -56,6 +56,7 @@ module "organization" {
   admin_permission_set_name = lookup(var.organization, "admin_permission_set_name", "AdministratorAccess")
   admin_group_name          = lookup(var.organization, "admin_group_name", "AllAdmins")
   disable_sso_management    = lookup(var.organization, "disable_sso_management", false)
+  sso_instance_region       = lookup(var.organization, "sso_instance_region", "us-east-1")
 
   # Audit Role
   deploy_audit_role = lookup(var.organization, "deploy_audit_role", true)

--- a/examples/pipeline/sample.tfvars
+++ b/examples/pipeline/sample.tfvars
@@ -26,6 +26,7 @@ organization = {
   admin_permission_set_name         = "AdministratorAccess"
   admin_group_name                  = "AllAdmins"
   disable_sso_management            = false
+  sso_instance_region               = "us-east-1"
   deploy_audit_role                 = true
   audit_role_name                   = "security-audit"
   audit_role_stack_set_template_url = "https://s3.amazonaws.com/pht-cloudformation/aws-account-automation/AuditRole-Template.yaml"

--- a/examples/pipeline/scripts/generate_regions.sh
+++ b/examples/pipeline/scripts/generate_regions.sh
@@ -21,7 +21,7 @@ else
   REPO=github.com/primeharbor/org-kickstart//modules/security_services?ref=$VERSION
 fi
 
-REPO=/Users/chris/AWS/org-kickstart/modules/security_services
+#REPO=/Users/chris/AWS/org-kickstart/modules/security_services
 
 REGIONS=`aws ec2 describe-regions  | jq -r '.Regions[].RegionName'`
 

--- a/modules/account/main.tf
+++ b/modules/account/main.tf
@@ -54,6 +54,12 @@ variable "disable_sso_management" {
   type = bool
 }
 
+variable "sso_instance_region" {
+  type        = string
+  default     = "us-east-1"
+  description = "Region where the AWS SSO instance is configured"
+}
+
 resource "aws_organizations_account" "account" {
   name      = var.account_name
   email     = var.account_email

--- a/modules/account/sso_assignment.tf
+++ b/modules/account/sso_assignment.tf
@@ -18,7 +18,7 @@
 # This allows terraform to reference attributes of the AWS SSO Identity Storey
 #
 data "aws_ssoadmin_instances" "identity_store" {
-    region = "eu-west-1" 
+    region =  var.sso_instance_region
 }
 
 locals {

--- a/modules/account/sso_assignment.tf
+++ b/modules/account/sso_assignment.tf
@@ -17,7 +17,9 @@
 #
 # This allows terraform to reference attributes of the AWS SSO Identity Storey
 #
-data "aws_ssoadmin_instances" "identity_store" {}
+data "aws_ssoadmin_instances" "identity_store" {
+    region = "eu-west-1" 
+}
 
 locals {
   identity_store_id = tolist(data.aws_ssoadmin_instances.identity_store.identity_store_ids)[0]

--- a/security_account.tf
+++ b/security_account.tf
@@ -30,6 +30,7 @@ module "security_account" {
   account_email            = var.security_account_root_email
   parent_ou_id             = aws_organizations_organizational_unit.governance_ou.id
   disable_sso_management   = var.disable_sso_management
+  sso_instance_region      = var.sso_instance_region
   admin_permission_set_arn = var.disable_sso_management ? null : aws_ssoadmin_permission_set.admin_permission_set[0].arn
   admin_group_id           = var.disable_sso_management ? null : aws_identitystore_group.admin_group[0].group_id
   billing_contact          = var.global_billing_contact

--- a/sso.tf
+++ b/sso.tf
@@ -14,7 +14,9 @@
 
 
 # SSO Should have been enabled prior to deploying the kickstart. In fact, it cannot be created via API, only console.
-data "aws_ssoadmin_instances" "identity_store" {}
+data "aws_ssoadmin_instances" "identity_store" {
+  region = var.sso_instance_region
+}
 
 locals {
   identity_store_id = tolist(data.aws_ssoadmin_instances.identity_store.identity_store_ids)[0]

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,12 @@ variable "admin_group_name" {
   type        = string
   default     = "AllAdmins"
 }
+variable "sso_instance_region" {
+  type        = string
+  default     = "us-east-1"
+  description = "Region where the AWS SSO instance is configured"
+}
+
 
 #
 # CloudTrail


### PR DESCRIPTION
`aws_ssoadmin_instances` assumes `us-east-1` as default region for SSO Instance configuration if not specified.  
However, if you're using external identity sources, it's advised to deploy the SSO instance to the region closer to the users.  
This small fix will allow a region to be specified for `aws_ssoadmin_instaces`, or assume `us-east-1` by default.

Chore 1: update `region` to `stack_set_instance_region` on  `aws_cloudformation_stack_set_instance.audit_role`, as the first is deprecated in new provider versions.

Chore 2: remove the static defintion of the $REPO variable on `generate_regions.sh` script.  