### PR TITLE
Configure ability to exclude certain services and policy types in AWS Orgs

### DIFF
--- a/audit-role.tf
+++ b/audit-role.tf
@@ -61,12 +61,12 @@ resource "aws_cloudformation_stack_set" "audit_role" {
 }
 
 resource "aws_cloudformation_stack_set_instance" "audit_role" {
-  count          = var.deploy_audit_role == true ? 1 : 0
-  provider       = aws.security-account
-  region         = "us-east-1"
-  call_as        = "DELEGATED_ADMIN"
-  retain_stack   = true
-  stack_set_name = aws_cloudformation_stack_set.audit_role[0].name
+  count                     = var.deploy_audit_role == true ? 1 : 0
+  provider                  = aws.security-account
+  stack_set_instance_region = "us-east-1"
+  call_as                   = "DELEGATED_ADMIN"
+  retain_stack              = true
+  stack_set_name            = aws_cloudformation_stack_set.audit_role[0].name
   deployment_targets {
     organizational_unit_ids = [aws_organizations_organization.org.roots[0].id]
   }

--- a/docs/v0.3.0-notes.md
+++ b/docs/v0.3.0-notes.md
@@ -24,7 +24,7 @@
     1. Added a aws_s3_bucket_public_access_block to the billing_logs bucket
     2. configure AWS KMS on the cloudtrail_s3_notification_topic and billing_alerts SNS Topics
     3. Fixed the block public access setting on VPC FlowLogs to restrict_public_buckets
-* Output Account Listing  - Thanks [skwashd](https://github.com/primeharbor/org-kickstart/commits?autappappffffffdddhor=skwashd)
+* Output Account Listing  - Thanks [skwashd](https://github.com/primeharbor/org-kickstart/commits?author=skwashd)
 * Enable User Notification service for Trusted access (Note: tf provider support doens't yet exist to configure this service.)
 * Account OUs can now be specified by both OU Name and OU ID.
 

--- a/docs/v0.3.0-notes.md
+++ b/docs/v0.3.0-notes.md
@@ -7,6 +7,9 @@
 * Add the ability to set the close-on-deletion setting for when an account is removed from the org.
 * Add optional support for DataTrails [PR14](https://github.com/primeharbor/org-kickstart/pull/14)
 * The Security Account is made the delegated administrator for Personal Health Dashboard - it will receive PHD events from all accounts in the organization
+* Ability to control stackset delegation to the security account. Thanks [Ashex](https://github.com/Ashex)!
+* Ability to explicitly exclude certian `aws_service_access_principals` and `enabled_policy_types`, via `aws_service_access_principals_to_exclude` and `organization_policy_types_to_exclude` Thanks [Ashex](https://github.com/Ashex)!
+
 
 ## Major Breaking Change
 * The Security Account is no longer default assigned as Delegated Admin for IAM Identity Center (sso).
@@ -21,7 +24,7 @@
     1. Added a aws_s3_bucket_public_access_block to the billing_logs bucket
     2. configure AWS KMS on the cloudtrail_s3_notification_topic and billing_alerts SNS Topics
     3. Fixed the block public access setting on VPC FlowLogs to restrict_public_buckets
-* Output Account Listing  - Thanks [skwashd](https://github.com/primeharbor/org-kickstart/commits?author=skwashd)
+* Output Account Listing  - Thanks [skwashd](https://github.com/primeharbor/org-kickstart/commits?autappappffffffdddhor=skwashd)
 * Enable User Notification service for Trusted access (Note: tf provider support doens't yet exist to configure this service.)
 * Account OUs can now be specified by both OU Name and OU ID.
 

--- a/examples/pipeline/main.tf
+++ b/examples/pipeline/main.tf
@@ -60,21 +60,24 @@ module "organization" {
   disable_sso_management    = lookup(var.organization, "disable_sso_management", false)
 
   # Audit Role
-  deploy_audit_role = lookup(var.organization, "deploy_audit_role", true)
-  audit_role_name   = lookup(var.organization, "audit_role_name", "security-audit")
+  deploy_audit_role                 = lookup(var.organization, "deploy_audit_role", true)
+  audit_role_name                   = lookup(var.organization, "audit_role_name", "security-audit")
+  audit_role_stack_set_template_url = lookup(var.organization, "audit_role_stack_set_template_url", null)
 
   # CloudTrail
   cloudtrail_bucket_name   = lookup(var.organization, "cloudtrail_bucket_name", null)
   cloudtrail_loggroup_name = lookup(var.organization, "cloudtrail_loggroup_name", null)
 
   # Map Objects
-  accounts                  = lookup(var.organization, "accounts", {})
-  service_control_policies  = lookup(var.organization, "service_control_policies", {})
-  resource_control_policies = lookup(var.organization, "resource_control_policies", {})
-  declarative_policies      = lookup(var.organization, "declarative_policies", {})
-  organization_units        = lookup(var.organization, "organization_units", {})
-  account_configurator      = lookup(var.organization, "account_configurator", null)
-  billing_alerts            = lookup(var.organization, "billing_alerts", null)
+  accounts                                 = lookup(var.organization, "accounts", {})
+  organization_policy_types_to_exclude     = lookup(var.organization, "organization_policy_types_to_exclude", null)
+  aws_service_access_principals_to_exclude = lookup(var.organization, "aws_service_access_principals_to_exclude", null)
+  service_control_policies                 = lookup(var.organization, "service_control_policies", {})
+  resource_control_policies                = lookup(var.organization, "resource_control_policies", {})
+  declarative_policies                     = lookup(var.organization, "declarative_policies", {})
+  organization_units                       = lookup(var.organization, "organization_units", {})
+  account_configurator                     = lookup(var.organization, "account_configurator", null)
+  billing_alerts                           = lookup(var.organization, "billing_alerts", null)
 
   # Global Alternate Contacts
   global_billing_contact    = lookup(var.organization, "global_billing_contact", null)
@@ -85,12 +88,14 @@ module "organization" {
   # Billing CUR Reports
   billing_data_bucket_name = lookup(var.organization, "billing_data_bucket_name", null)
   cur_report_frequency     = lookup(var.organization, "cur_report_frequency", "NONE")
+  budget_defaults          = lookup(var.organization, "budget_defaults", null)
 
   # Security Stuff
   security_services              = lookup(var.organization, "security_services", {})
   vpc_flowlogs_bucket_name       = lookup(var.organization, "vpc_flowlogs_bucket_name", null)
   macie_bucket_name              = lookup(var.organization, "macie_bucket_name", null)
   declarative_policy_bucket_name = lookup(var.organization, "declarative_policy_bucket_name", null)
+  datatrail                      = lookup(var.organization, "datatrail", null)
 }
 
 variable "organization" {}

--- a/examples/pipeline/main.tf
+++ b/examples/pipeline/main.tf
@@ -15,7 +15,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 5.99.1"
     }
   }
   required_version = ">= 0.14.9"
@@ -72,6 +73,7 @@ module "organization" {
   accounts                                 = lookup(var.organization, "accounts", {})
   organization_policy_types_to_exclude     = lookup(var.organization, "organization_policy_types_to_exclude", null)
   aws_service_access_principals_to_exclude = lookup(var.organization, "aws_service_access_principals_to_exclude", null)
+  aws_service_access_principals_to_enable  = lookup(var.organization, "aws_service_access_principals_to_enable", null)
   service_control_policies                 = lookup(var.organization, "service_control_policies", {})
   resource_control_policies                = lookup(var.organization, "resource_control_policies", {})
   declarative_policies                     = lookup(var.organization, "declarative_policies", {})

--- a/examples/pipeline/sample.tfvars
+++ b/examples/pipeline/sample.tfvars
@@ -127,6 +127,14 @@ organization = {
     # website_url     = "Optional"
   }
 
+  aws_service_access_principals_to_exclude = [
+    "ipam.amazonaws.com"
+  ]
+
+  organization_policy_types_to_exclude = [
+    "TAG_POLICY"
+  ]
+
   service_control_policies = {
     deny_root = {
       policy_name        = "DenyRoot"

--- a/examples/pipeline/sample.tfvars
+++ b/examples/pipeline/sample.tfvars
@@ -131,6 +131,10 @@ organization = {
     "ipam.amazonaws.com"
   ]
 
+  aws_service_access_principals_to_enable = [
+    "securitylake.amazonaws.com",
+  ]
+
   organization_policy_types_to_exclude = [
     "TAG_POLICY"
   ]

--- a/modules/datatrail/trail.tf
+++ b/modules/datatrail/trail.tf
@@ -93,7 +93,7 @@ data "aws_iam_policy_document" "datatrail_bucket" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = ["arn:${data.aws_partition.payer.partition}:cloudtrail:${data.aws_region.payer.name}:${data.aws_caller_identity.payer.account_id}:trail/${var.trail_name}"]
+      values   = ["arn:${data.aws_partition.payer.partition}:cloudtrail:${data.aws_region.payer.region}:${data.aws_caller_identity.payer.account_id}:trail/${var.trail_name}"]
     }
   }
 
@@ -117,7 +117,7 @@ data "aws_iam_policy_document" "datatrail_bucket" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = ["arn:${data.aws_partition.payer.partition}:cloudtrail:${data.aws_region.payer.name}:${data.aws_caller_identity.payer.account_id}:trail/${var.trail_name}"]
+      values   = ["arn:${data.aws_partition.payer.partition}:cloudtrail:${data.aws_region.payer.region}:${data.aws_caller_identity.payer.account_id}:trail/${var.trail_name}"]
     }
   }
 }

--- a/organization.tf
+++ b/organization.tf
@@ -22,16 +22,20 @@ locals {
   default_aws_service_access_principals = [
     "access-analyzer.amazonaws.com",
     "account.amazonaws.com",
+    "aws-artifact-account-sync.amazonaws.com",
     "backup.amazonaws.com",
     "cloudtrail.amazonaws.com",
+    "compute-optimizer.amazonaws.com",
     "config-multiaccountsetup.amazonaws.com",
     "config.amazonaws.com",
+    "cost-optimization-hub.bcm.amazonaws.com",
     "ec2.amazonaws.com",
     "fms.amazonaws.com",
     "guardduty.amazonaws.com",
     "health.amazonaws.com",
     "iam.amazonaws.com",
     "inspector2.amazonaws.com",
+    "ipam.amazonaws.com",
     "license-management.marketplace.amazonaws.com",
     "license-manager.amazonaws.com",
     "license-manager.member-account.amazonaws.com",
@@ -41,9 +45,13 @@ locals {
     "notifications.amazonaws.com",
     "ram.amazonaws.com",
     "reporting.trustedadvisor.amazonaws.com",
+    "resource-explorer-2.amazonaws.com",
     "securityhub.amazonaws.com",
+    "servicequotas.amazonaws.com",
     "ssm.amazonaws.com",
     "sso.amazonaws.com",
+    "storage-lens.s3.amazonaws.com",
+    "tagpolicies.tag.amazonaws.com",
   ]
 
   default_enabled_policy_types = [
@@ -54,15 +62,23 @@ locals {
     "SERVICE_CONTROL_POLICY",
     "TAG_POLICY"
   ]
+
+  filtered_aws_service_access_principals = [
+    for principal in local.default_aws_service_access_principals :
+    principal if !(contains(var.aws_service_access_principals_to_exclude, principal))
+  ]
+
+  filtered_enabled_policy_types = [
+    for policy in local.default_enabled_policy_types :
+    policy if !(contains(var.organization_policy_types_to_exclude, policy))
+  ]
 }
 
 
 # Create the organization
 resource "aws_organizations_organization" "org" {
-  aws_service_access_principals = var.aws_service_access_principals != null ? var.aws_service_access_principals : local.default_aws_service_access_principals
-
-  enabled_policy_types = var.enabled_policy_types != null ? var.enabled_policy_types : local.default_enabled_policy_types
-
+  aws_service_access_principals = local.filtered_aws_service_access_principals
+  enabled_policy_types = local.filtered_enabled_policy_types
   feature_set = "ALL"
 }
 

--- a/organization.tf
+++ b/organization.tf
@@ -57,14 +57,23 @@ locals {
   default_enabled_policy_types = [
     "AISERVICES_OPT_OUT_POLICY",
     "BACKUP_POLICY",
+    "CHATBOT_POLICY",
     "DECLARATIVE_POLICY_EC2",
     "RESOURCE_CONTROL_POLICY",
+    "SECURITYHUB_POLICY",
     "SERVICE_CONTROL_POLICY",
     "TAG_POLICY"
   ]
 
+  merged_aws_service_access_principals = distinct(
+    concat(
+      local.default_aws_service_access_principals,
+      var.aws_service_access_principals_to_enable
+    )
+  )
+
   filtered_aws_service_access_principals = [
-    for principal in local.default_aws_service_access_principals :
+    for principal in local.merged_aws_service_access_principals :
     principal if !(contains(var.aws_service_access_principals_to_exclude, principal))
   ]
 
@@ -78,8 +87,8 @@ locals {
 # Create the organization
 resource "aws_organizations_organization" "org" {
   aws_service_access_principals = local.filtered_aws_service_access_principals
-  enabled_policy_types = local.filtered_enabled_policy_types
-  feature_set = "ALL"
+  enabled_policy_types          = local.filtered_enabled_policy_types
+  feature_set                   = "ALL"
 }
 
 # Enable management of root credentials

--- a/variables.tf
+++ b/variables.tf
@@ -363,6 +363,12 @@ variable "aws_service_access_principals_to_exclude" {
   default     = []
 }
 
+variable "aws_service_access_principals_to_enable" {
+  description = "List of AWS service access principals to enable if they're not part of the default set."
+  type        = list(string)
+  default     = []
+}
+
 variable "organization_policy_types_to_exclude" {
   description = "List of organization policy types to exclude from the default set."
   type        = list(string)
@@ -425,5 +431,16 @@ variable "datatrail" {
     trail_name       = string
     enabled          = optional(bool, true)
     excluded_buckets = list(string)
+  })
+}
+
+variable "user_notifications" {
+  description = "Configuration for user notifications."
+  type = object({
+    enabled                 = optional(bool, false)
+    contact_email           = string
+    contact_name            = string
+    aggregation_duration    = optional(string, "LONG")
+    notification_hub_region = optional(string, "us-east-1")
   })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -433,14 +433,3 @@ variable "datatrail" {
     excluded_buckets = list(string)
   })
 }
-
-variable "user_notifications" {
-  description = "Configuration for user notifications."
-  type = object({
-    enabled                 = optional(bool, false)
-    contact_email           = string
-    contact_name            = string
-    aggregation_duration    = optional(string, "LONG")
-    notification_hub_region = optional(string, "us-east-1")
-  })
-}

--- a/variables.tf
+++ b/variables.tf
@@ -357,16 +357,16 @@ variable "declarative_policies" {
   }))
 }
 
-variable "aws_service_access_principals" {
-  description = "List of AWS service principals to enable in the organization"
+variable "aws_service_access_principals_to_exclude" {
+  description = "List of AWS service access principals to exclude from the default set."
   type        = list(string)
-  default     = null
+  default     = []
 }
 
-variable "enabled_policy_types" {
-  description = "List of enabled policy types for the organization"
+variable "organization_policy_types_to_exclude" {
+  description = "List of organization policy types to exclude from the default set."
   type        = list(string)
-  default     = null
+  default     = []
 }
 
 
@@ -395,7 +395,7 @@ variable "deploy_audit_role" {
 # Security Service flags
 variable "security_services" {
   description = "Explicitly disable or not manage a security service"
-  type        = object({
+  type = object({
     disable_guardduty   = optional(bool, false)
     disable_macie       = optional(bool, false)
     disable_inspector   = optional(bool, false)


### PR DESCRIPTION
Take Evelyn's PR and flip it to be a list of excluded service_access_principals and enabled_policy_types.
But add an override of new service_access_principals that may not yet be the default
And Fix some deprecated resource attributes. 