### PR TITLE
Region and partition fixes

### DIFF
--- a/accounts.tf
+++ b/accounts.tf
@@ -32,5 +32,6 @@ module "accounts" {
   operations_contact       = lookup(each.value, "operations_contact", var.global_operations_contact)
   primary_contact          = lookup(each.value, "primary_contact", var.global_primary_contact)
   disable_sso_management   = var.disable_sso_management
+  sso_instance_region      = var.sso_instance_region
 }
 

--- a/audit-role.tf
+++ b/audit-role.tf
@@ -61,12 +61,12 @@ resource "aws_cloudformation_stack_set" "audit_role" {
 }
 
 resource "aws_cloudformation_stack_set_instance" "audit_role" {
-  count          = var.deploy_audit_role == true ? 1 : 0
-  provider       = aws.security-account
-  region         = "us-east-1"
-  call_as        = "DELEGATED_ADMIN"
-  retain_stack   = true
-  stack_set_name = aws_cloudformation_stack_set.audit_role[0].name
+  count                     = var.deploy_audit_role == true ? 1 : 0
+  provider                  = aws.security-account
+  stack_set_instance_region = "us-east-1"
+  call_as                   = "DELEGATED_ADMIN"
+  retain_stack              = true
+  stack_set_name            = aws_cloudformation_stack_set.audit_role[0].name
   deployment_targets {
     organizational_unit_ids = [aws_organizations_organization.org.roots[0].id]
   }

--- a/audit-role.tf
+++ b/audit-role.tf
@@ -30,7 +30,7 @@ resource "aws_cloudformation_stack_set" "audit_role" {
   # Bug with provider https://github.com/hashicorp/terraform-provider-aws/issues/23464
   # TF attempts to remove the administration_role_arn, even though it's added as part of a tf refresh
   # Workaround is the lifecycle block
-  # administration_role_arn = "arn:aws:iam::${local.payer_account_id}:role/aws-service-role/stacksets.cloudformation.amazonaws.com/AWSServiceRoleForCloudFormationStackSetsOrgAdmin"
+  # administration_role_arn = "arn:${data.aws_partition.current.partition}:iam::${local.payer_account_id}:role/aws-service-role/stacksets.cloudformation.amazonaws.com/AWSServiceRoleForCloudFormationStackSetsOrgAdmin"
   lifecycle {
     ignore_changes = [
       administration_role_arn

--- a/billing.tf
+++ b/billing.tf
@@ -86,7 +86,7 @@ data "aws_iam_policy_document" "allow_billing_logging" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:cur:us-east-1:${aws_organizations_account.payer.id}:definition/*"]
+      values   = ["arn:aws:cur:${data.aws_region.current.name}:${aws_organizations_account.payer.id}:definition/*"]
     }
 
   }
@@ -112,7 +112,7 @@ resource "aws_cur_report_definition" "cur_report_definition" {
   additional_schema_elements = ["RESOURCES", "SPLIT_COST_ALLOCATION_DATA"]
   s3_bucket                  = aws_s3_bucket.billing_logs[0].id
   s3_prefix                  = "athena-cur-report"
-  s3_region                  = "us-east-1"
+  s3_region                  = data.aws_region.current.name
   additional_artifacts       = ["ATHENA"]
   report_versioning          = "OVERWRITE_REPORT"
 }

--- a/billing.tf
+++ b/billing.tf
@@ -112,7 +112,7 @@ resource "aws_cur_report_definition" "cur_report_definition" {
   additional_schema_elements = ["RESOURCES", "SPLIT_COST_ALLOCATION_DATA"]
   s3_bucket                  = aws_s3_bucket.billing_logs[0].id
   s3_prefix                  = "athena-cur-report"
-  s3_region                  = data.aws_region.current.name
+  s3_region                  = data.aws_region.current.region
   additional_artifacts       = ["ATHENA"]
   report_versioning          = "OVERWRITE_REPORT"
 }

--- a/billing.tf
+++ b/billing.tf
@@ -86,7 +86,7 @@ data "aws_iam_policy_document" "allow_billing_logging" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:cur:${data.aws_region.current.name}:${aws_organizations_account.payer.id}:definition/*"]
+      values   = ["arn:${data.aws_partition.current.partition}:cur:${data.aws_region.current.region}:${aws_organizations_account.payer.id}:definition/*"]
     }
 
   }

--- a/cloudtrail.tf
+++ b/cloudtrail.tf
@@ -106,7 +106,7 @@ data "aws_iam_policy_document" "cloudtrail_bucket_policy" {
     condition {
       test     = "StringLike"
       variable = "aws:PrincipalArn"
-      values   = ["arn:aws:iam::&{aws:PrincipalAccount}:role/service-role/AccessAnalyzerMonitorServiceRole*"]
+      values   = ["arn:${data.aws_partition.current.partition}:iam::&{aws:PrincipalAccount}:role/service-role/AccessAnalyzerMonitorServiceRole*"]
     }
   }
 }
@@ -125,7 +125,7 @@ data "aws_iam_policy_document" "cloudtrail_s3_notification_topic" {
     }
 
     actions   = ["SNS:Publish"]
-    resources = ["arn:aws:sns:*:*:cloudtrail-s3-event-notification-topic"]
+    resources = ["arn:${data.aws_partition.current.partition}:sns:*:*:cloudtrail-s3-event-notification-topic"]
 
     condition {
       test     = "ArnLike"

--- a/declarative_policies.tf
+++ b/declarative_policies.tf
@@ -68,7 +68,7 @@ data "aws_iam_policy_document" "declarative_policy_bucket_policy" {
     condition {
       test     = "StringLike"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:declarative-policies-ec2:*:${aws_organizations_account.payer.id}:*"]
+      values   = ["arn:${data.aws_partition.current.partition}:declarative-policies-ec2:*:${aws_organizations_account.payer.id}:*"]
     }
   }
 }

--- a/examples/pipeline/CodePipeline-Template.yaml
+++ b/examples/pipeline/CodePipeline-Template.yaml
@@ -145,14 +145,14 @@ Resources:
                   - s3:Get*
                   - s3:ListBucket
                 Resource:
-                 - !Sub arn:aws:s3:::${PipelineBucket}
+                 - !Sub arn:${AWS::Partition}:s3:::${PipelineBucket}
               - Sid: AccessPipelineBucketObjects
                 Effect: Allow
                 Action:
                   - s3:PutObject*
                   - s3:GetObject*
                 Resource:
-                  - !Sub arn:aws:s3:::${PipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${PipelineBucket}/*
 
   Pipeline:
     Type: AWS::CodePipeline::Pipeline
@@ -269,7 +269,7 @@ Resources:
               Service:
                 - codebuild.amazonaws.com
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AdministratorAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AdministratorAccess
       Policies:
         - PolicyName: root
           PolicyDocument:
@@ -288,7 +288,7 @@ Resources:
                   - s3:Get*
                   - s3:ListBucket
                 Resource:
-                 - !Sub arn:aws:s3:::${PipelineBucket}
+                 - !Sub arn:${AWS::Partition}:s3:::${PipelineBucket}
               - Sid: AccessPipelineBucketObjects
                 Effect: Allow
                 Action:
@@ -297,7 +297,7 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:GetBucketVersioning
                 Resource:
-                  - !Sub arn:aws:s3:::${PipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${PipelineBucket}/*
 
   TerraformPlanProject:
     Type: AWS::CodeBuild::Project

--- a/examples/pipeline/main.tf
+++ b/examples/pipeline/main.tf
@@ -56,6 +56,7 @@ module "organization" {
   admin_permission_set_name = lookup(var.organization, "admin_permission_set_name", "AdministratorAccess")
   admin_group_name          = lookup(var.organization, "admin_group_name", "AllAdmins")
   disable_sso_management    = lookup(var.organization, "disable_sso_management", false)
+  sso_instance_region       = lookup(var.organization, "sso_instance_region", "us-east-1")
 
   # Audit Role
   deploy_audit_role = lookup(var.organization, "deploy_audit_role", true)

--- a/examples/pipeline/main.tf
+++ b/examples/pipeline/main.tf
@@ -21,7 +21,7 @@ terraform {
   }
   required_version = ">= 0.14.9"
 
-  # This is configured in the $env.backend file
+  # This is configured in the $env.tfbackend file, see sample.tfbackend
   backend "s3" {
 
   }

--- a/examples/pipeline/main.tf
+++ b/examples/pipeline/main.tf
@@ -23,7 +23,7 @@ terraform {
 
   # This is configured in the $env.backend file
   backend "s3" {
-    region = "us-east-1"
+
   }
 }
 

--- a/examples/pipeline/sample.tfbackend
+++ b/examples/pipeline/sample.tfbackend
@@ -12,5 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# See documentation for implementation details
+# https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+
 bucket="org-kickstart-13456789012"
 key="org-kickstart.tfstate"
+region = "us-east-1"

--- a/examples/pipeline/sample.tfvars
+++ b/examples/pipeline/sample.tfvars
@@ -26,6 +26,7 @@ organization = {
   admin_permission_set_name         = "AdministratorAccess"
   admin_group_name                  = "AllAdmins"
   disable_sso_management            = false
+  sso_instance_region               = "us-east-1"
   deploy_audit_role                 = true
   audit_role_name                   = "security-audit"
   audit_role_stack_set_template_url = "https://s3.amazonaws.com/pht-cloudformation/aws-account-automation/AuditRole-Template.yaml"

--- a/examples/pipeline/scripts/generate_regions.sh
+++ b/examples/pipeline/scripts/generate_regions.sh
@@ -21,7 +21,7 @@ else
   REPO=github.com/primeharbor/org-kickstart//modules/security_services?ref=$VERSION
 fi
 
-REPO=/Users/chris/AWS/org-kickstart/modules/security_services
+#REPO=/Users/chris/AWS/org-kickstart/modules/security_services
 
 REGIONS=`aws ec2 describe-regions  | jq -r '.Regions[].RegionName'`
 

--- a/macie_bucket.tf
+++ b/macie_bucket.tf
@@ -114,7 +114,7 @@ resource "aws_kms_key_policy" "macie_key" {
         Action = "kms:*"
         Effect = "Allow"
         Principal = {
-          AWS = "arn:aws:iam::${module.security_account.account_id}:root"
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${module.security_account.account_id}:root"
         }
         Resource = "*"
       },

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,6 @@ locals {
 # Create Default Provider for Management Account
 #
 provider "aws" {
-  region = "us-east-1"
   default_tags {
     tags = local.default_tags
   }
@@ -45,7 +44,6 @@ provider "aws" {
 
 provider "aws" {
   alias  = "security-account"
-  region = "us-east-1"
   assume_role {
     role_arn = "arn:aws:iam::${module.security_account.account_id}:role/OrganizationAccountAccessRole"
   }
@@ -53,3 +51,5 @@ provider "aws" {
     tags = local.default_tags
   }
 }
+
+data "aws_region" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -43,9 +43,9 @@ provider "aws" {
 }
 
 provider "aws" {
-  alias  = "security-account"
+  alias = "security-account"
   assume_role {
-    role_arn = "arn:aws:iam::${module.security_account.account_id}:role/OrganizationAccountAccessRole"
+    role_arn = "arn:${data.aws_partition.current.partition}:iam::${module.security_account.account_id}:role/OrganizationAccountAccessRole"
   }
   default_tags {
     tags = local.default_tags
@@ -53,3 +53,5 @@ provider "aws" {
 }
 
 data "aws_region" "current" {}
+
+data "aws_partition" "current" {}

--- a/modules/account/main.tf
+++ b/modules/account/main.tf
@@ -54,6 +54,12 @@ variable "disable_sso_management" {
   type = bool
 }
 
+variable "sso_instance_region" {
+  type        = string
+  default     = "us-east-1"
+  description = "Region where the AWS SSO instance is configured"
+}
+
 resource "aws_organizations_account" "account" {
   name      = var.account_name
   email     = var.account_email

--- a/modules/account/sso_assignment.tf
+++ b/modules/account/sso_assignment.tf
@@ -18,7 +18,7 @@
 # This allows terraform to reference attributes of the AWS SSO Identity Storey
 #
 data "aws_ssoadmin_instances" "identity_store" {
-    region =  var.sso_instance_region
+  region = var.sso_instance_region
 }
 
 locals {

--- a/modules/account/sso_assignment.tf
+++ b/modules/account/sso_assignment.tf
@@ -18,7 +18,7 @@
 # This allows terraform to reference attributes of the AWS SSO Identity Storey
 #
 data "aws_ssoadmin_instances" "identity_store" {
-    region = "eu-west-1" 
+    region =  var.sso_instance_region
 }
 
 locals {

--- a/modules/account/sso_assignment.tf
+++ b/modules/account/sso_assignment.tf
@@ -17,7 +17,9 @@
 #
 # This allows terraform to reference attributes of the AWS SSO Identity Storey
 #
-data "aws_ssoadmin_instances" "identity_store" {}
+data "aws_ssoadmin_instances" "identity_store" {
+    region = "eu-west-1" 
+}
 
 locals {
   identity_store_id = tolist(data.aws_ssoadmin_instances.identity_store.identity_store_ids)[0]

--- a/modules/datatrail/trail.tf
+++ b/modules/datatrail/trail.tf
@@ -34,7 +34,7 @@ resource "aws_cloudtrail" "datatrail" {
     field_selector {
       field = "resources.ARN"
       # Exclude the passed in list, and always exclude the data trail bucket itself to prevent recursion
-      not_starts_with = [for bucket in concat(var.excluded_buckets, [var.bucket_name]) : "arn:aws:s3:::${bucket}/"]
+      not_starts_with = [for bucket in concat(var.excluded_buckets, [var.bucket_name]) : "arn:${data.aws_partition.payer.partition}:s3:::${bucket}/"]
     }
 
     field_selector {

--- a/modules/stacksets/main.tf
+++ b/modules/stacksets/main.tf
@@ -25,7 +25,7 @@ resource "aws_cloudformation_stack_set" "stack_set" {
   # Bug with provider https://github.com/hashicorp/terraform-provider-aws/issues/23464
   # TF attempts to remove the administration_role_arn, even though it's added as part of a tf refresh
   # Workaround is the lifecycle block
-  # administration_role_arn = "arn:aws:iam::${local.payer_account_id}:role/aws-service-role/stacksets.cloudformation.amazonaws.com/AWSServiceRoleForCloudFormationStackSetsOrgAdmin"
+  # administration_role_arn = "arn:${data.aws_partition.current.partition}:iam::${local.payer_account_id}:role/aws-service-role/stacksets.cloudformation.amazonaws.com/AWSServiceRoleForCloudFormationStackSetsOrgAdmin"
   lifecycle {
     ignore_changes = [
       administration_role_arn

--- a/security_account.tf
+++ b/security_account.tf
@@ -30,6 +30,7 @@ module "security_account" {
   account_email            = var.security_account_root_email
   parent_ou_id             = aws_organizations_organizational_unit.governance_ou.id
   disable_sso_management   = var.disable_sso_management
+  sso_instance_region      = var.sso_instance_region
   admin_permission_set_arn = var.disable_sso_management ? null : aws_ssoadmin_permission_set.admin_permission_set[0].arn
   admin_group_id           = var.disable_sso_management ? null : aws_identitystore_group.admin_group[0].group_id
   billing_contact          = var.global_billing_contact

--- a/security_hub.tf
+++ b/security_hub.tf
@@ -95,10 +95,7 @@ resource "aws_securityhub_configuration_policy" "no_enabled_standards" {
 
   configuration_policy {
     service_enabled = true
-    enabled_standard_arns = [
-      #   "arn:aws:securityhub:us-east-1::standards/aws-foundational-security-best-practices/v/1.0.0",
-      #   "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0",
-    ]
+    enabled_standard_arns = [ ]
     security_controls_configuration {
       disabled_control_identifiers = []
     }

--- a/security_hub.tf
+++ b/security_hub.tf
@@ -94,8 +94,8 @@ resource "aws_securityhub_configuration_policy" "no_enabled_standards" {
   description = "Enable Security Hub Central Configuration without any Standards"
 
   configuration_policy {
-    service_enabled = true
-    enabled_standard_arns = [ ]
+    service_enabled       = true
+    enabled_standard_arns = []
     security_controls_configuration {
       disabled_control_identifiers = []
     }

--- a/sso.tf
+++ b/sso.tf
@@ -28,7 +28,7 @@ resource "aws_ssoadmin_managed_policy_attachment" "admin_policy_attachments" {
   depends_on         = [aws_ssoadmin_permission_set.admin_permission_set[0]]
   instance_arn       = local.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.admin_permission_set[0].arn
-  managed_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  managed_policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AdministratorAccess"
 }
 
 resource "aws_ssoadmin_permission_set" "admin_permission_set" {

--- a/sso.tf
+++ b/sso.tf
@@ -14,7 +14,9 @@
 
 
 # SSO Should have been enabled prior to deploying the kickstart. In fact, it cannot be created via API, only console.
-data "aws_ssoadmin_instances" "identity_store" {}
+data "aws_ssoadmin_instances" "identity_store" {
+  region = var.sso_instance_region
+}
 
 locals {
   identity_store_id = tolist(data.aws_ssoadmin_instances.identity_store.identity_store_ids)[0]

--- a/templates/AuditRole-Template.yaml
+++ b/templates/AuditRole-Template.yaml
@@ -49,10 +49,10 @@ Resources:
     Properties:
       RoleName: !Ref RoleName
       ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/SecurityAudit
-      - arn:aws:iam::aws:policy/ReadOnlyAccess
-      - arn:aws:iam::aws:policy/AWSAccountManagementReadOnlyAccess
-      - arn:aws:iam::aws:policy/AWSSSOReadOnly
+      - !Sub arn:${AWS::Partition}:iam::aws:policy/SecurityAudit
+      - !Sub arn:${AWS::Partition}:iam::aws:policy/ReadOnlyAccess
+      - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSAccountManagementReadOnlyAccess
+      - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSSSOReadOnly
       Path: /
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -61,7 +61,7 @@ Resources:
           Sid: ''
           Effect: Allow
           Principal:
-            AWS: !Sub "arn:aws:iam::${TrustedAccountNumber}:root"
+            AWS: !Sub "arn:${AWS::Partition}:iam::${TrustedAccountNumber}:root"
       Policies:
         - PolicyName: MissingPermissions
           PolicyDocument:

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,12 @@ variable "admin_group_name" {
   type        = string
   default     = "AllAdmins"
 }
+variable "sso_instance_region" {
+  type        = string
+  default     = "us-east-1"
+  description = "Region where the AWS SSO instance is configured"
+}
+
 
 #
 # CloudTrail


### PR DESCRIPTION
This PR fixes a number of issues around hard-coded regions and Partitions.
1. It should now be possible to determine the region that will be used for AWS Identity Center thanks to @monfardineL
2. Leverage the current region (usually defined in the local config or AWS_DEFAULT_REGION envvar) thanks to @Ashex
3. Multiple References to the `aws` partition (the commercial region) have been configured to use the partition data source in preparation for the launch of the European Sovereign Cloud. 