### PR TITLE
Migrate to the enhanced region support in the 6.0 AWS Provider

### DIFF
--- a/docs/v0.3.0-notes.md
+++ b/docs/v0.3.0-notes.md
@@ -55,3 +55,40 @@
 
 ## Known Bugs
 1. You can't use the `parent_ou_name` for OUs that are not direct descendants of the Root OU
+
+
+## Migrating Security Services from Region Based Providers to Region Variable.
+
+With the introduction of the region variable in the 6.x version of the AWS Provider, the need for the `generate_regions.sh` script has gone away. If you were managing security services via the dedicated providers for payer and security account, you will need to tell terraform to "move" them to the new resource locations.
+
+This migration script should handle generating the moved resources:
+```bash
+#!/bin/bash
+
+> moves.tf
+REGIONS=`aws ec2 describe-regions  | jq -r '.Regions[].RegionName'`
+
+for r in $REGIONS ; do
+  cat <<EOF >> moves.tf
+
+# $r
+moved {
+    from = module.security-services-$r.aws_guardduty_detector.payer_detector[0]
+    to = module.organization.module.security-services["$r"].aws_guardduty_detector.payer_detector[0]
+}
+moved {
+    from = module.security-services-$r.aws_guardduty_detector.security_detector[0]
+    to = module.organization.module.security-services["$r"].aws_guardduty_detector.security_detector[0]
+}
+moved {
+    from = module.security-services-$r.aws_guardduty_organization_admin_account.guardduty[0]
+    to = module.organization.module.security-services["$r"].aws_guardduty_organization_admin_account.guardduty[0]
+}
+moved {
+    from =  module.security-services-$r.aws_guardduty_organization_configuration.organization[0]
+    to = module.organization.module.security-services["$r"].aws_guardduty_organization_configuration.organization[0]
+}
+EOF
+
+done
+```

--- a/examples/pipeline/README.md
+++ b/examples/pipeline/README.md
@@ -50,21 +50,6 @@ Overview
   ```bash
   make tf-apply
   ```
-9. Generate the multi-region files and re-run the plan:
-  ```bash
-  ./scripts/generate_regions.sh
-  make tf-init
-  make tf-plan
-  ```
-
-
-
-If you see the following error:
-```
-Error: listing Organizations Accounts for parent (r-117h) and descendants: AccessDeniedException: You don't have permissions to access this resource.
-```
-You need to delete the `security_services.tf`, apply the changes, then re-generate the file from the `generate_regions.sh` script. The Security Account _must_ have delegated admin enabled before this resources can be plan'ed or apply'd
-
 
 ## Post Deploy
 

--- a/examples/pipeline/scripts/generate_regions.sh
+++ b/examples/pipeline/scripts/generate_regions.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+echo "This script has be deprecated in v1.0, and remains only if needed for migration forward"
+exit 1
+
 VERSION=$1
 
 if [[ -z "$VERSION" ]] ; then

--- a/modules/security_services/guardduty.tf
+++ b/modules/security_services/guardduty.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Chris Farris <chris@primeharbor.com>
+# Copyright 2023-2026 Chris Farris <chris@primeharbor.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,18 +17,21 @@
 resource "aws_guardduty_detector" "payer_detector" {
   count    = var.security_services["disable_guardduty"] ? 0 : 1
   provider = aws.payer_account
+  region   = var.region
   enable   = true
 }
 
 resource "aws_guardduty_detector" "security_detector" {
   count    = var.security_services["disable_guardduty"] ? 0 : 1
   provider = aws.security_account
+  region   = var.region
   enable   = true
 }
 
 # Assign delegated admin to the security account via GuardDuty APIs
 resource "aws_guardduty_organization_admin_account" "guardduty" {
   count    = var.security_services["disable_guardduty"] ? 0 : 1
+  region   = var.region
   provider = aws.payer_account
   depends_on = [
     aws_guardduty_detector.payer_detector,
@@ -42,6 +45,7 @@ resource "aws_guardduty_organization_configuration" "organization" {
   count                            = var.security_services["disable_guardduty"] ? 0 : 1
   depends_on                       = [aws_guardduty_organization_admin_account.guardduty]
   provider                         = aws.security_account
+  region                           = var.region
   auto_enable_organization_members = "ALL"
   detector_id                      = aws_guardduty_detector.security_detector[0].id
 }

--- a/modules/security_services/macie.tf
+++ b/modules/security_services/macie.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Chris Farris <chris@primeharbor.com>
+# Copyright 2023-2026 Chris Farris <chris@primeharbor.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 resource "aws_macie2_account" "payer_account" {
   count                        = var.security_services["disable_macie"] ? 0 : 1
   provider                     = aws.payer_account
+  region                       = var.region
   finding_publishing_frequency = "FIFTEEN_MINUTES"
   status                       = "ENABLED"
 }
@@ -24,6 +25,7 @@ resource "aws_macie2_account" "payer_account" {
 resource "aws_macie2_account" "security_account" {
   count                        = var.security_services["disable_macie"] ? 0 : 1
   provider                     = aws.security_account
+  region                       = var.region
   finding_publishing_frequency = "FIFTEEN_MINUTES"
   status                       = "ENABLED"
 }
@@ -32,6 +34,7 @@ resource "aws_macie2_account" "security_account" {
 resource "aws_macie2_organization_admin_account" "macie" {
   count    = var.security_services["disable_macie"] ? 0 : 1
   provider = aws.payer_account
+  region   = var.region
   depends_on = [
     aws_macie2_account.payer_account,
     aws_macie2_account.security_account,
@@ -42,6 +45,7 @@ resource "aws_macie2_organization_admin_account" "macie" {
 resource "aws_macie2_classification_export_configuration" "export_config" {
   count    = var.security_services["disable_macie"] || var.macie_bucket_name == null || var.macie_key_arn == null ? 0 : 1
   provider = aws.security_account
+  region   = var.region
   depends_on = [
     aws_macie2_account.security_account
   ]
@@ -55,6 +59,7 @@ resource "aws_macie2_classification_export_configuration" "export_config" {
 # This adds all the existing accounts to the delegated admin
 resource "aws_macie2_member" "member" {
   provider   = aws.security_account
+  region     = var.region
   depends_on = [aws_macie2_organization_admin_account.macie]
   account_id = each.key
   email      = each.value["email"]

--- a/modules/security_services/main.tf
+++ b/modules/security_services/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Chris Farris <chris@primeharbor.com>
+# Copyright 2023-2026 Chris Farris <chris@primeharbor.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,11 @@ terraform {
 }
 
 variable "security_account_id" {}
+
+variable "region" {
+  type        = string
+  description = "Region to Deploy Services into"
+}
 
 # Create a bucket and stuff if this is defined
 variable "macie_bucket_name" {

--- a/security_services.tf
+++ b/security_services.tf
@@ -1,0 +1,37 @@
+# Copyright 2026 Chris Farris <chris@primeharbor.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Data source to dynamically fetch all available AWS regions
+data "aws_regions" "available" {
+  all_regions = false # Only include regions that are enabled in your account
+}
+
+locals {
+  # Uses the aws_regions data source to automatically discover all enabled regions
+  aws_regions = data.aws_regions.available.names
+}
+
+module "security-services" {
+  for_each = toset(local.aws_regions)
+  region   = each.value
+  source   = "./modules/security_services"
+  providers = {
+    aws.security_account = aws.security-account
+    aws.payer_account    = aws
+  }
+  security_account_id = module.security_account.account_id
+  security_services   = var.security_services
+  # macie_key_arn       = module.organization.macie_key_arn
+  # macie_bucket_name   = var.organization["macie_bucket_name"]
+}


### PR DESCRIPTION
This PR moved from creating dedicated providers for the payer & security account to using the new region variable introduced here: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-upgrade#enhanced-region-support
 
This will be a breaking change 