### PR TITLE
Make IAM Identity Center region configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ organization = {
   admin_permission_set_name         = "AdministratorAccess"
   admin_group_name                  = "AllAdmins"
   disable_sso_management            = false
+  identity_center_region            = "us-east-1" # Region where IAM Identity Center is enabled
   deploy_audit_role                 = true
   audit_role_name                   = "security-audit"
   audit_role_stack_set_template_url = "https://s3.amazonaws.com/pht-cloudformation/aws-account-automation/AuditRole-Template.yaml"

--- a/accounts.tf
+++ b/accounts.tf
@@ -21,6 +21,10 @@
 module "accounts" {
   for_each = var.accounts
   source   = "./modules/account"
+  providers = {
+    aws                 = aws
+    aws.identity_center = aws.identity_center
+  }
 
   account_name             = each.value["account_name"]
   account_email            = each.value["account_email"]

--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,17 @@ locals {
 }
 
 #
+# Region where IAM Identity Center (AWS SSO) is enabled. Identity Center is a
+# regional service, so all sso-admin / identity-store resources must be managed
+# in this region. Defaults to us-east-1 to preserve existing behavior.
+#
+variable "identity_center_region" {
+  description = "Region in which IAM Identity Center (AWS SSO) is enabled"
+  type        = string
+  default     = "us-east-1"
+}
+
+#
 # Create Default Provider for Management Account
 #
 provider "aws" {
@@ -63,6 +74,17 @@ provider "aws" {
     tags = local.default_tags
   }
 
+}
+
+#
+# Provider pinned to the IAM Identity Center region for all SSO resources
+#
+provider "aws" {
+  alias  = "identity_center"
+  region = var.identity_center_region
+  default_tags {
+    tags = local.default_tags
+  }
 }
 
 provider "aws" {

--- a/modules/account/providers.tf
+++ b/modules/account/providers.tf
@@ -1,0 +1,24 @@
+# Copyright 2023 Chris Farris <chris@primeharbor.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      # aws.identity_center must be supplied by the caller and points at the
+      # region where IAM Identity Center is enabled (see root identity_center_region).
+      configuration_aliases = [aws, aws.identity_center]
+    }
+  }
+}

--- a/modules/account/sso_assignment.tf
+++ b/modules/account/sso_assignment.tf
@@ -17,7 +17,9 @@
 #
 # This allows terraform to reference attributes of the AWS SSO Identity Storey
 #
-data "aws_ssoadmin_instances" "identity_store" {}
+data "aws_ssoadmin_instances" "identity_store" {
+  provider = aws.identity_center
+}
 
 locals {
   identity_store_id = tolist(data.aws_ssoadmin_instances.identity_store.identity_store_ids)[0]
@@ -25,6 +27,7 @@ locals {
 }
 
 resource "aws_ssoadmin_account_assignment" "account_group_assignment" {
+  provider           = aws.identity_center
   count              = var.disable_sso_management == true ? 0 : 1
   instance_arn       = local.instance_arn
   permission_set_arn = var.admin_permission_set_arn

--- a/security_account.tf
+++ b/security_account.tf
@@ -25,6 +25,10 @@
 # We explictly create a security account.
 module "security_account" {
   source = "./modules/account"
+  providers = {
+    aws                 = aws
+    aws.identity_center = aws.identity_center
+  }
 
   account_name             = var.security_account_name
   account_email            = var.security_account_root_email

--- a/sso.tf
+++ b/sso.tf
@@ -14,7 +14,9 @@
 
 
 # SSO Should have been enabled prior to deploying the kickstart. In fact, it cannot be created via API, only console.
-data "aws_ssoadmin_instances" "identity_store" {}
+data "aws_ssoadmin_instances" "identity_store" {
+  provider = aws.identity_center
+}
 
 locals {
   identity_store_id = tolist(data.aws_ssoadmin_instances.identity_store.identity_store_ids)[0]
@@ -22,6 +24,7 @@ locals {
 }
 
 resource "aws_ssoadmin_managed_policy_attachment" "admin_policy_attachments" {
+  provider           = aws.identity_center
   count              = var.disable_sso_management == true ? 0 : 1
   depends_on         = [aws_ssoadmin_permission_set.admin_permission_set[0]]
   instance_arn       = local.instance_arn
@@ -30,6 +33,7 @@ resource "aws_ssoadmin_managed_policy_attachment" "admin_policy_attachments" {
 }
 
 resource "aws_ssoadmin_permission_set" "admin_permission_set" {
+  provider     = aws.identity_center
   count        = var.disable_sso_management == true ? 0 : 1
   name         = var.admin_permission_set_name
   description  = "Grant Full Admin Permissions"
@@ -39,6 +43,7 @@ resource "aws_ssoadmin_permission_set" "admin_permission_set" {
 }
 
 resource "aws_identitystore_group" "admin_group" {
+  provider          = aws.identity_center
   count             = var.disable_sso_management == true ? 0 : 1
   display_name      = var.admin_group_name
   description       = "Default Group for all Cloud Admins"


### PR DESCRIPTION
## Problem

IAM Identity Center (AWS SSO) is a **regional** service, but all sso-admin / identity-store resources currently run through the default provider, which is pinned to `us-east-1`. Organizations that enabled Identity Center in a different home region (e.g. `ap-southeast-2`) can't deploy org-kickstart without forking it — the `aws_ssoadmin_*` / `aws_identitystore_*` calls hit the wrong region.

## Change

- Add an `identity_center_region` variable, **defaulting to `us-east-1`** so existing deployments are completely unaffected.
- Add a dedicated `aws.identity_center` provider configured to that region.
- Route all SSO / identity-store resources through it: the root `sso.tf` resources and the `account_assignment` in `modules/account`. The submodule receives the provider via `configuration_aliases`, passed from the two `module` calls.
- Document the new tfvar in the README sample.

## Backward compatibility

Fully backward compatible. Anyone not setting `identity_center_region` gets `us-east-1` — identical to today's behavior. Users whose Identity Center lives elsewhere set e.g. `identity_center_region = "ap-southeast-2"`.

Validated with `terraform validate`; verified as a no-op against a live org whose Identity Center is in `ap-southeast-2` (plan shows no changes when the variable matches the existing region).