### PR TITLE
Fix declarative_policy_bucket output crash when bucket is not created

### DIFF
--- a/declarative_policies.tf
+++ b/declarative_policies.tf
@@ -89,5 +89,6 @@ module "declarative_policies" {
 }
 
 output "declarative_policy_bucket" {
-  value = aws_s3_bucket.declarative_policy_bucket[0].id
+  # Bucket is gated on declarative_policy_bucket_name; one() yields null when unset.
+  value = one(aws_s3_bucket.declarative_policy_bucket[*].id)
 }


### PR DESCRIPTION
## Problem

`declarative_policies.tf` declares the bucket as count-gated:

```hcl
resource "aws_s3_bucket" "declarative_policy_bucket" {
  count = var.declarative_policy_bucket_name == null ? 0 : 1
  ...
}
```

but the output indexes `[0]` unconditionally:

```hcl
output "declarative_policy_bucket" {
  value = aws_s3_bucket.declarative_policy_bucket[0].id
}
```

When `declarative_policy_bucket_name` is left unset (the default), the bucket has `count = 0`, and **every `terraform plan` errors out**:

```
Error: Invalid index
  on declarative_policies.tf line 92, in output "declarative_policy_bucket":
  92:   value = aws_s3_bucket.declarative_policy_bucket[0].id
    aws_s3_bucket.declarative_policy_bucket is empty tuple
```

This blocks anyone adopting v0.2.0 who isn't using declarative-policy reporting.

## Fix

Use `one()`, which returns the single element when count is 1 and `null` when count is 0:

```hcl
value = one(aws_s3_bucket.declarative_policy_bucket[*].id)
```

The other `[0]` references in this file are inside resources gated by the same `count` condition, so they're only evaluated when the bucket exists — the ungated output was the only broken spot.

Verified: `terraform plan` completes cleanly with `declarative_policy_bucket_name` unset.