### PR TITLE
Add payer_cloudformation_stacks and security_account_stacks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,22 @@ terraform import -var-file="<env>.tfvars" <resource_address> <resource_id>
 
 ## Important Conventions
 
+### Release Notes (do this on every commit)
+
+Every change MUST be recorded in the release-notes file for the version it targets:
+`docs/v<MAJOR>.<MINOR>.<PATCH>-notes.md` (e.g. [docs/v0.3.0-notes.md](docs/v0.3.0-notes.md)). When
+preparing a commit, add a bullet to the appropriate section of that file describing the change:
+
+- **New Features** — new variables, resources, or capabilities
+- **Major / Minor Breaking Change** — anything requiring a `terraform state mv`, recreation, or a
+  tfvars change to keep working (include the migration steps)
+- **Minor Updates** — small enhancements, dependency bumps, lint/Checkov fixes
+- **Bug Fixes** — corrected behavior (e.g. `depends_on` ordering, validation fixes)
+- **Known Bugs** — anything still broken that users should be aware of
+
+If the target version doesn't have a notes file yet, create it. Treat a missing release-notes entry
+the same as a missing test: the change isn't done until it's documented.
+
 ### Partition Awareness
 
 The code uses `data.aws_partition.current.partition` to support commercial, GovCloud, and other AWS partitions. When constructing ARNs, always use: `arn:${data.aws_partition.current.partition}:service:...`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,8 @@ terraform import -var-file="<env>.tfvars" <resource_address> <resource_id>
 
 **Managing account contacts**: Use `global_billing_contact`, `global_security_contact`, `global_operations_contact`, and `global_primary_contact` for organization-wide defaults. Override per-account in account definition.
 
+**Adding a new top-level variable / feature**: When introducing a new variable in [variables.tf](variables.tf) that callers should be able to set via tfvars, also wire it through [examples/pipeline/main.tf](examples/pipeline/main.tf). Callers consume this module by passing a single `organization` object, so each variable must be re-exposed in the example module block with a `lookup(var.organization, "<var_name>", <default>)` pass-through. Skipping this step means callers can put the value in their tfvars but it will be silently ignored. Also update [examples/pipeline/sample.tfvars](examples/pipeline/sample.tfvars) so the feature is discoverable.
+
 ## Important Conventions
 
 ### Partition Awareness

--- a/docs/v0.3.0-notes.md
+++ b/docs/v0.3.0-notes.md
@@ -1,5 +1,6 @@
 # New Features
 * Add a generic CloudFormation Stackset Capability
+* Add `payer_cloudformation_stacks` and `security_account_stacks` to deploy arbitrary CloudFormation stacks into the payer and security accounts directly from Terraform. Each is a map keyed by an HCL identifier and expanded across optional `regions` (composite addresses like `aws_cloudformation_stack.payer["billing_alerts-us-east-1"]` so adding a region later doesn't rename existing stacks). Templates come from a local `template_file` (relative to `path.root`) or an HTTPS/S3 `template_url` — exactly one is required.
 * Account attribute allows you to specify which AWS Organizations services the account is Delegated Admin for
 * Add Organizational Budget support
 * Add individual account budget support

--- a/examples/pipeline/main.tf
+++ b/examples/pipeline/main.tf
@@ -79,6 +79,8 @@ module "organization" {
   declarative_policies                     = lookup(var.organization, "declarative_policies", {})
   organization_units                       = lookup(var.organization, "organization_units", {})
   account_configurator                     = lookup(var.organization, "account_configurator", null)
+  payer_cloudformation_stacks              = lookup(var.organization, "payer_cloudformation_stacks", {})
+  security_account_stacks                  = lookup(var.organization, "security_account_stacks", {})
   billing_alerts                           = lookup(var.organization, "billing_alerts", null)
 
   # Global Alternate Contacts

--- a/examples/pipeline/sample.tfvars
+++ b/examples/pipeline/sample.tfvars
@@ -249,6 +249,47 @@ organization = {
     account_factory_config_file = "account-config.yaml"
   }
 
+
+  # These stacks are automatically deployed to the AWS Payer Account.
+  # Set exactly one of template_file (local path, relative to path.root) or
+  # template_url (S3/HTTPS URL). Optional: regions (defaults to the base
+  # org-kickstart region), timeout_in_minutes (default 15), on_failure
+  # (DO_NOTHING|ROLLBACK|DELETE, default DO_NOTHING).
+  payer_cloudformation_stacks = {
+    billing_alerts = {
+      stack_name    = "slack_billing_alerts"
+      template_file = "cloudformation/slack-Template.yaml"
+      regions       = ["us-east-1"]
+      parameters = {
+        pExecutionRate      = "cron(0 09 * * ? *)"
+        pEventInput         = <<-EOT
+          {
+            "threshold": "10",
+            "alert_percent": "20"
+          }
+        EOT
+        pSlackWebhookSecret = "SlackWebHook"
+        pRuleState          = "ENABLED"
+        pAccountDescription = "My-Payer"
+      }
+    }
+  }
+
+  # These stacks are automatically deployed to the Security Account using the
+  # OrganizationAccountAccessRole. Same schema as payer_cloudformation_stacks.
+  security_account_stacks = {
+    findings_processor = {
+      stack_name    = "security-findings-processor"
+      template_file = "cloudformation/findings-processor-Template.yaml"
+      regions       = ["us-east-1"]
+      parameters = {
+        pSlackWebhookSecret = "SlackWebHook"
+        pSeverityThreshold  = "MEDIUM"
+      }
+    }
+  }
+
+
   billing_alerts = {
     levels = {
       level1  = 10

--- a/payer_stacks.tf
+++ b/payer_stacks.tf
@@ -1,0 +1,57 @@
+# Copyright 2026 Chris Farris <chris@primeharbor.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  # Expand stack x regions so each stack-region pair gets a stable address
+  # like aws_cloudformation_stack.payer["billing_alerts-us-east-1"]. When
+  # regions is omitted, default to the base org-kickstart region.
+  payer_stacks_expanded = merge([
+    for k, v in var.payer_cloudformation_stacks : {
+      for region in coalesce(v.regions, [data.aws_region.current.region]) : "${k}-${region}" => {
+        stack_name         = v.stack_name
+        template_file      = v.template_file
+        template_url       = v.template_url
+        region             = region
+        parameters         = v.parameters
+        timeout_in_minutes = v.timeout_in_minutes
+        on_failure         = v.on_failure
+      }
+    }
+  ]...)
+}
+
+resource "aws_cloudformation_stack" "payer" {
+  for_each = local.payer_stacks_expanded
+
+  name          = each.value.stack_name
+  region        = each.value.region
+  template_body = each.value.template_file != null ? file("${path.root}/${each.value.template_file}") : null
+  template_url  = each.value.template_url
+
+  # Canonicalize any parameter value that happens to parse as JSON so
+  # whitespace-only differences (heredocs, indentation) don't show up as
+  # drift on subsequent plans. Non-JSON strings pass through unchanged.
+  parameters = {
+    for k, v in each.value.parameters : k => try(jsonencode(jsondecode(v)), v)
+  }
+
+  timeout_in_minutes = each.value.timeout_in_minutes
+  # on_failure         = each.value.on_failure
+
+  capabilities = [
+    "CAPABILITY_IAM",
+    "CAPABILITY_NAMED_IAM",
+    "CAPABILITY_AUTO_EXPAND"
+  ]
+}

--- a/security_stacks.tf
+++ b/security_stacks.tf
@@ -1,0 +1,58 @@
+# Copyright 2026 Chris Farris <chris@primeharbor.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  # Expand stack x regions so each stack-region pair gets a stable address
+  # like aws_cloudformation_stack.security["findings_processor-us-east-1"].
+  # When regions is omitted, default to the base org-kickstart region.
+  security_stacks_expanded = merge([
+    for k, v in var.security_account_stacks : {
+      for region in coalesce(v.regions, [data.aws_region.current.region]) : "${k}-${region}" => {
+        stack_name         = v.stack_name
+        template_file      = v.template_file
+        template_url       = v.template_url
+        region             = region
+        parameters         = v.parameters
+        timeout_in_minutes = v.timeout_in_minutes
+        on_failure         = v.on_failure
+      }
+    }
+  ]...)
+}
+
+resource "aws_cloudformation_stack" "security" {
+  for_each = local.security_stacks_expanded
+  provider = aws.security-account
+
+  name          = each.value.stack_name
+  region        = each.value.region
+  template_body = each.value.template_file != null ? file("${path.root}/${each.value.template_file}") : null
+  template_url  = each.value.template_url
+
+  # Canonicalize any parameter value that happens to parse as JSON so
+  # whitespace-only differences (heredocs, indentation) don't show up as
+  # drift on subsequent plans. Non-JSON strings pass through unchanged.
+  parameters = {
+    for k, v in each.value.parameters : k => try(jsonencode(jsondecode(v)), v)
+  }
+
+  timeout_in_minutes = each.value.timeout_in_minutes
+  # on_failure         = each.value.on_failure
+
+  capabilities = [
+    "CAPABILITY_IAM",
+    "CAPABILITY_NAMED_IAM",
+    "CAPABILITY_AUTO_EXPAND"
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -226,6 +226,58 @@ variable "account_configurator" {
     template                    = string
   })
 }
+
+variable "payer_cloudformation_stacks" {
+  description = "Map of CloudFormation stacks to deploy into the payer account. Exactly one of template_file (local path relative to path.root) or template_url (S3/HTTPS URL) must be set per stack. If regions is omitted, the stack is deployed only in the base org-kickstart region."
+  default     = {}
+  type = map(
+    object({
+      stack_name         = string
+      template_file      = optional(string)
+      template_url       = optional(string)
+      regions            = optional(list(string))
+      parameters         = optional(map(string), {})
+      timeout_in_minutes = optional(number, 15)
+      on_failure         = optional(string, "DO_NOTHING")
+    })
+  )
+
+  validation {
+    condition     = alltrue([for k, v in var.payer_cloudformation_stacks : (v.template_file == null) != (v.template_url == null)])
+    error_message = "Each payer_cloudformation_stacks entry must specify exactly one of template_file or template_url."
+  }
+
+  validation {
+    condition     = alltrue([for k, v in var.payer_cloudformation_stacks : contains(["DO_NOTHING", "ROLLBACK", "DELETE"], v.on_failure)])
+    error_message = "on_failure must be one of DO_NOTHING, ROLLBACK, DELETE."
+  }
+}
+
+variable "security_account_stacks" {
+  description = "Map of CloudFormation stacks to deploy into the security account. Exactly one of template_file (local path relative to path.root) or template_url (S3/HTTPS URL) must be set per stack. If regions is omitted, the stack is deployed only in the base org-kickstart region."
+  default     = {}
+  type = map(
+    object({
+      stack_name         = string
+      template_file      = optional(string)
+      template_url       = optional(string)
+      regions            = optional(list(string))
+      parameters         = optional(map(string), {})
+      timeout_in_minutes = optional(number, 15)
+      on_failure         = optional(string, "DO_NOTHING")
+    })
+  )
+
+  validation {
+    condition     = alltrue([for k, v in var.security_account_stacks : (v.template_file == null) != (v.template_url == null)])
+    error_message = "Each security_account_stacks entry must specify exactly one of template_file or template_url."
+  }
+
+  validation {
+    condition     = alltrue([for k, v in var.security_account_stacks : contains(["DO_NOTHING", "ROLLBACK", "DELETE"], v.on_failure)])
+    error_message = "on_failure must be one of DO_NOTHING, ROLLBACK, DELETE."
+  }
+}
 variable "backend_bucket" {
   description = "Name of the S3 bucket used for the CloudFormation stacks and Terraform state backend"
   type        = string


### PR DESCRIPTION
Deploys arbitrary CloudFormation stacks into the payer account and the security account from Terraform. Each is a map keyed by HCL identifier, with stack x region expansion producing composite addresses like aws_cloudformation_stack.payer["billing_alerts-us-east-1"] so adding a region later does not rename existing stacks.

Templates are sourced from either a local file (template_file, relative to path.root) or an HTTPS/S3 URL (template_url); exactly one is required. regions is optional and defaults to the base org-kickstart region. Capabilities are hardcoded to CAPABILITY_IAM, CAPABILITY_NAMED_IAM, and CAPABILITY_AUTO_EXPAND.

JSON parameter values are canonicalized via try(jsonencode(jsondecode(v)), v) so heredoc-formatted JSON does not show whitespace drift on subsequent plans. Non-JSON values pass through unchanged.

CLAUDE.md updated to remind future contributors that new top-level variables also need a pass-through in examples/pipeline/main.tf, since callers consume this module through a single organization object.