### PR TITLE
Add explicit depends_on to fix first-apply ordering race condition

### DIFF
--- a/ai_policy.tf
+++ b/ai_policy.tf
@@ -14,6 +14,11 @@
 
 
 resource "aws_organizations_policy" "ai_policy" {
+  # The org enables the AISERVICES_OPT_OUT_POLICY type and must exist before any policy is
+  # created; this resource doesn't otherwise reference the org, so depend on it explicitly to
+  # avoid an "account is not a member of an organization" race on first apply.
+  depends_on = [aws_organizations_organization.org]
+
   name    = "ai_policy"
   type    = "AISERVICES_OPT_OUT_POLICY"
   content = <<EOF

--- a/billing.tf
+++ b/billing.tf
@@ -124,6 +124,11 @@ resource "aws_s3_bucket_policy" "allow_billing_logging" {
 # These recommendations are from Mike Julian @ the Duckbill Group
 #
 resource "aws_cur_report_definition" "cur_report_definition" {
+  # CUR verifies it can read/write the bucket at create time, so the bucket policy granting the
+  # billingreports.amazonaws.com principal must be in place first. The s3_bucket reference only
+  # orders against the bucket itself, not its policy.
+  depends_on = [aws_s3_bucket_policy.allow_billing_logging]
+
   count                      = var.cur_report_frequency != "NONE" ? 1 : 0
   report_name                = "athena-cur-report"
   time_unit                  = var.cur_report_frequency

--- a/declarative_policies.tf
+++ b/declarative_policies.tf
@@ -77,6 +77,10 @@ data "aws_iam_policy_document" "declarative_policy_bucket_policy" {
 # Declarative Policies
 #
 module "declarative_policies" {
+  # The created policy resource doesn't reference the org directly (only its attachment does),
+  # so depend on the org explicitly to avoid racing org creation / policy-type enablement.
+  depends_on = [aws_organizations_organization.org]
+
   for_each = var.declarative_policies
 
   source             = "./modules/org_policies"

--- a/docs/v0.3.0-notes.md
+++ b/docs/v0.3.0-notes.md
@@ -54,6 +54,11 @@
 
     Otherwise they'll be recreated.
 
+## Bug Fixes
+* Added explicit `depends_on` to several Organizations resources that previously raced creation on a first apply:
+    * The AI opt-out policy (`aws_organizations_policy.ai_policy`), RAM organization sharing (`aws_ram_sharing_with_organization.enable`), and the SCP / RCP / Declarative policy modules now depend on `aws_organizations_organization.org`. These resources only referenced the org indirectly (through a separate policy attachment), so Terraform could create them before the org existed, producing `AWSOrganizationsNotInUseException` ("Your account is not a member of an organization") errors.
+    * The CUR report definition (`aws_cur_report_definition.cur_report_definition`) now depends on the billing bucket policy (`aws_s3_bucket_policy.allow_billing_logging`) so CUR's create-time bucket-permission check doesn't run before the policy is in place.
+
 ## Known Bugs
 1. You can't use the `parent_ou_name` for OUs that are not direct descendants of the Root OU
 

--- a/organization.tf
+++ b/organization.tf
@@ -108,4 +108,7 @@ resource "aws_iam_organizations_features" "org" {
 data "aws_organizations_organization" "org" {}
 
 # Enable resource sharing within the org without the need for invites.
-resource "aws_ram_sharing_with_organization" "enable" {}
+# Depends on the org explicitly so it doesn't race org creation on first apply.
+resource "aws_ram_sharing_with_organization" "enable" {
+  depends_on = [aws_organizations_organization.org]
+}

--- a/rcps.tf
+++ b/rcps.tf
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 module "rcp" {
+  # The created policy resource doesn't reference the org directly (only its attachment does),
+  # so depend on the org explicitly to avoid racing org creation / policy-type enablement.
+  depends_on = [aws_organizations_organization.org]
+
   for_each = var.resource_control_policies
 
   source             = "./modules/org_policies"

--- a/scps.tf
+++ b/scps.tf
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 module "scp" {
+  # The created policy resource doesn't reference the org directly (only its attachment does),
+  # so depend on the org explicitly to avoid racing org creation / policy-type enablement.
+  depends_on = [aws_organizations_organization.org]
+
   for_each = var.service_control_policies
 
   source             = "./modules/org_policies"


### PR DESCRIPTION
Add explicit depends_on to fix first-apply ordering race conditions
Several Organizations resources reference the org only through a sibling
attachment, so Terraform never orders them after the org resource and
they race creation on a first apply ("account is not a member of an
organization"). Add explicit depends_on:

- ai_policy, RAM sharing, and the scp/rcp/declarative policy modules
  depend on aws_organizations_organization.org
- the CUR report definition depends on the billing bucket policy so
  CUR's bucket-permission check doesn't run before the policy lands

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>