### PR TITLE
Honor sso_instance_region on all SSO resources (PR #30)

### DIFF
--- a/docs/v0.3.1-notes.md
+++ b/docs/v0.3.1-notes.md
@@ -1,0 +1,14 @@
+# New Features
+
+_None yet._
+
+## Bug Fixes
+
+* IAM Identity Center (SSO) resources now honor `sso_instance_region`. Previously only the
+  `aws_ssoadmin_instances` data source was region-aware; the permission set, admin group,
+  managed-policy attachment, and account assignments (payer and per-account) were created in the
+  default provider region. Deploying with Identity Center enabled in a non-default region therefore
+  targeted the wrong region. Each SSO resource now sets `region = var.sso_instance_region` — the
+  provider-v6 per-resource equivalent of the provider-alias approach in
+  [PR #30](https://github.com/primeharbor/org-kickstart/pull/30) (which was merged only against the
+  `0.2.0` branch).

--- a/modules/account/sso_assignment.tf
+++ b/modules/account/sso_assignment.tf
@@ -28,6 +28,7 @@ locals {
 
 resource "aws_ssoadmin_account_assignment" "account_group_assignment" {
   count              = var.disable_sso_management == true ? 0 : 1
+  region             = var.sso_instance_region
   instance_arn       = local.instance_arn
   permission_set_arn = var.admin_permission_set_arn
   principal_id       = var.admin_group_id

--- a/payer.tf
+++ b/payer.tf
@@ -26,6 +26,7 @@ resource "aws_organizations_account" "payer" {
 
 resource "aws_ssoadmin_account_assignment" "payer_account_group_assignment" {
   count              = var.disable_sso_management == true ? 0 : 1
+  region             = var.sso_instance_region
   instance_arn       = local.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.admin_permission_set[0].arn
   principal_id       = aws_identitystore_group.admin_group[0].group_id

--- a/sso.tf
+++ b/sso.tf
@@ -25,6 +25,7 @@ locals {
 
 resource "aws_ssoadmin_managed_policy_attachment" "admin_policy_attachments" {
   count              = var.disable_sso_management == true ? 0 : 1
+  region             = var.sso_instance_region
   depends_on         = [aws_ssoadmin_permission_set.admin_permission_set[0]]
   instance_arn       = local.instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.admin_permission_set[0].arn
@@ -33,6 +34,7 @@ resource "aws_ssoadmin_managed_policy_attachment" "admin_policy_attachments" {
 
 resource "aws_ssoadmin_permission_set" "admin_permission_set" {
   count        = var.disable_sso_management == true ? 0 : 1
+  region       = var.sso_instance_region
   name         = var.admin_permission_set_name
   description  = "Grant Full Admin Permissions"
   instance_arn = local.instance_arn
@@ -42,6 +44,7 @@ resource "aws_ssoadmin_permission_set" "admin_permission_set" {
 
 resource "aws_identitystore_group" "admin_group" {
   count             = var.disable_sso_management == true ? 0 : 1
+  region            = var.sso_instance_region
   display_name      = var.admin_group_name
   description       = "Default Group for all Cloud Admins"
   identity_store_id = local.identity_store_id


### PR DESCRIPTION
Only the aws_ssoadmin_instances data sources honored sso_instance_region; the permission set, admin group, managed-policy attachment, and the payer and per-account assignments were created in the default provider region. Since Identity Center instance ARNs carry no region, deploying with SSO in a non-default region targeted the wrong region.

Add region = var.sso_instance_region to each SSO resource -- the provider-v6 per-resource equivalent of PR #30 (which only merged against the 0.2.0 branch).

Thanks to @mattgillard for the fix and for flagging it (PR #30).